### PR TITLE
PST Serial Response Box Support

### DIFF
--- a/psychopy/iohub/constants.py
+++ b/psychopy/iohub/constants.py
@@ -137,7 +137,8 @@ try:
 
         SERIAL_INPUT = 105
         SERIAL_BYTE_CHANGE = 106
-
+        PSTBOX_BUTTON = 107
+        
         MULTI_CHANNEL_ANALOG_INPUT=122
 
         MESSAGE=151
@@ -231,6 +232,9 @@ try:
             #: Constant for a serial event due to a rx stream byte value change.
             SERIAL_BYTE_CHANGE = 106
 
+            #: Constant for a PST Box serial interface event due to a button state change.
+            PSTBOX_BUTTON = 107
+            
             #: Constant for an Experiment Message Event.
             MESSAGE=151
 

--- a/psychopy/iohub/constants.py
+++ b/psychopy/iohub/constants.py
@@ -139,7 +139,7 @@ try:
         SERIAL_BYTE_CHANGE = 106
 
         MULTI_CHANNEL_ANALOG_INPUT=122
-    
+
         MESSAGE=151
         LOG=152
 
@@ -299,6 +299,7 @@ try:
         GAMEPAD = 80
         MCU = 100
         SERIAL = 110
+        PSTBOX = 111
         ANALOGINPUT = 120
         EXPERIMENT = 150
         DISPLAY = 190
@@ -337,7 +338,10 @@ try:
             MCU = 100
 
             #: Constant for a General Purpose Serial Interface Device.
-            MCU = 110
+            SERIAL = 110
+
+            #: Constant for PST Serial Response Box
+            PSTBOX = 111
 
             #: Constant for an AnalogInput Device.
             ANALOGINPUT = 120

--- a/psychopy/iohub/datastore/__init__.py
+++ b/psychopy/iohub/datastore/__init__.py
@@ -39,9 +39,9 @@ perhaps one less than this.  < S. Simpson Note: These are 'not' GIL bound
 threads and therefore actually improve performance > """
 
 DATA_FILE_TITLE = "ioHub DataStore - Experiment Data File."
-FILE_VERSION = '0.8.0.2'
+FILE_VERSION = '0.8.1.1'
 SCHEMA_AUTHORS = 'Sol Simpson'
-SCHEMA_MODIFIED_DATE = 'May 4th, 2014'
+SCHEMA_MODIFIED_DATE = 'Dec 19th, 2014'
 
         
 class ioHubpyTablesFile():
@@ -179,6 +179,12 @@ class ioHubpyTablesFile():
             pass
 
         try:
+            self.TABLES['PSTBOX_BUTTON'] = self.emrtFile.root.data_collection.events.serial.PstBoxButtonEvent
+        except:
+            # Just means the table for this event type has not been created as the event type is not being recorded
+            pass
+
+        try:
             self.TABLES['MONOCULAR_EYE_SAMPLE']=self.emrtFile.root.data_collection.events.eyetracker.MonocularEyeSampleEvent
         except:
             # Just means the table for this event type has not been created as the event type is not being recorded
@@ -278,6 +284,7 @@ class ioHubpyTablesFile():
         self._eventGroupMappings['DIGITAL_INPUT']=self.emrtFile.root.data_collection.events.mcu
         self._eventGroupMappings['SERIAL_INPUT']=self.emrtFile.root.data_collection.events.serial
         self._eventGroupMappings['SERIAL_BYTE_CHANGE']=self.emrtFile.root.data_collection.events.serial
+        self._eventGroupMappings['PSTBOX_BUTTON']=self.emrtFile.root.data_collection.events.serial
         self._eventGroupMappings['MESSAGE']=self.emrtFile.root.data_collection.events.experiment
         self._eventGroupMappings['LOG']=self.emrtFile.root.data_collection.events.experiment
         self._eventGroupMappings['MONOCULAR_EYE_SAMPLE']=self.emrtFile.root.data_collection.events.eyetracker

--- a/psychopy/iohub/devices/serial/__init__.py
+++ b/psychopy/iohub/devices/serial/__init__.py
@@ -651,6 +651,26 @@ class PstBoxButtonEvent(DeviceEvent):
     ]
 
     __slots__ = [e[0] for e in _newDataTypes]
+    
+    # As is, this event will not work. This is because new fields have been added
+    # for the event. iohub not only supports streaming of events to psychopy at runtime, but
+    # it also stores events in the 'datastore', which is an hdf5 structured file.
+    # Each event type that has a specific set of fields different from other events must 
+    # have a table created to hold the event types data. Each table as columns that are created from
+    # the event classes datatypes dtype definition string.
+    
+    # Need to first know if this event type really should have  / needs the prev_byte and current_byte
+    # fields created in the SerialByteChangeEvent. If it does, then
+    # extending SerialByteChangeEvent as is done now makes sense . 
+    # If it does not need these fields, then it would be better
+    # to extend the base DeviceEvent class. 
+    
+    # Regardless, the following changes need to be added to this file, 
+    EVENT_TYPE_ID = EventConstants.PSTBOX_BUTTON
+    EVENT_TYPE_STRING = 'PSTBOX_BUTTON'
+    IOHUB_DATA_TABLE = EVENT_TYPE_STRING    
+    
+    # TODO: and an update to constants.py and maybe datastore.__init__.py will be needed
 
     # Specify Event constants associated with the event class, 
     # and the key to the hdf5 table these events should be stored in.

--- a/psychopy/iohub/devices/serial/__init__.py
+++ b/psychopy/iohub/devices/serial/__init__.py
@@ -461,14 +461,14 @@ class Serial(Device):
         Device._close(self)
 
 
-class PstBox(Serial):
+class Pstbox(Serial):
     """
     Provides convenient access to the PST Serial Response Box.
 
     """
-    EVENT_CLASS_NAMES = ['SerialInputEvent', 'PstBoxButtonEvent']
+    EVENT_CLASS_NAMES = ['SerialInputEvent', 'PstboxButtonEvent']
     DEVICE_TYPE_ID = DeviceConstants.PSTBOX
-    DEVICE_TYPE_STRING = "PSTBOX"
+    DEVICE_TYPE_STRING = 'PSTBOX'
     # Only add new attributes for the subclass, the device metaclass pulls them together. 
     _serial_slots = [
         '_nlamps', '_lamp_state',
@@ -478,7 +478,7 @@ class PstBox(Serial):
     __slots__ = [e for e in _serial_slots]
 
     def __init__(self, *args, **kwargs):
-        Serial.__init__(self, *args, **kwargs['dconfig'])
+        Serial.__init__(self, *args, **kwargs)
 
         # Any class instance attribute must be specified in the __slots__ list.
         # So '_nbuttons' needs to be added to __slots__ for this class.
@@ -642,8 +642,8 @@ class SerialByteChangeEvent(DeviceEvent):
     def __init__(self, *args, **kwargs):
         DeviceEvent.__init__(self, *args, **kwargs)
 
-class PstBoxButtonEvent(DeviceEvent):
-    # Add new fields for PstBoxButtonEvent
+class PstboxButtonEvent(DeviceEvent):
+    # Add new fields for PstboxButtonEvent
     _newDataTypes = [
         ('port', N.str, 32), # could be needed to identify events from >1 connected button box; if that is ever supported.
         ('button', N.uint8),

--- a/psychopy/iohub/devices/serial/__init__.py
+++ b/psychopy/iohub/devices/serial/__init__.py
@@ -487,10 +487,7 @@ class Pstbox(Serial):
         self._nbuttons = 5
         # Buttons 0--4, from left to right:
         # [1, 2, 4, 8, 16]
-        # FIXME Make use of msgpack-numpy
-        self._button_bytes = list(
-            (2**N.arange(self._nbuttons)).astype(N.uint8)
-        )
+        self._button_bytes = 2**N.arange(self._nbuttons, dtype='uint8')
 
         self._nlamps = 5
         self._lamp_state = N.repeat(False, self._nlamps)
@@ -524,12 +521,10 @@ class Pstbox(Serial):
         self._state = state
 
     def getState(self):
-        # FIXME Make use of msgpack-numpy
-        return [bool(x) for x in self._state]
+        return self._state
 
     def getLampState(self):
-        # FIXME Make use of msgpack-numpy
-        return [bool(x) for x in self._lamp_state]
+        return self._lamp_state
 
     def setLampState(self, state):
         """
@@ -592,10 +587,10 @@ class Pstbox(Serial):
         new_byte = ord(new_byte)
 
         if new_byte != 0:  # Button was pressed
-            button = self._button_bytes.index(new_byte)
+            button = N.where(self._button_bytes == new_byte)[0][0]
             button_event = 'press'
         else:  # Button was released
-            button = self._button_bytes.index(prev_byte)
+            button = N.where(self._button_bytes == prev_byte)[0][0]
             button_event = 'release'
 
         events = [

--- a/psychopy/iohub/devices/serial/__init__.py
+++ b/psychopy/iohub/devices/serial/__init__.py
@@ -16,38 +16,45 @@ from ...constants import DeviceConstants, EventConstants
 import numpy as N
 getTime = Computer.getTime
 
+
 class Serial(Device):
     """
     A general purpose serial input interface device. Configuration options
     are used to define how the serial input data should be parsed, and what
     conditions create a serial input event to be generated.
     """
-    _bytesizes = {5: serial.FIVEBITS,
-                  6: serial.SIXBITS,
-                  7: serial.SEVENBITS,
-                  8: serial.EIGHTBITS,
-                  }
+    _bytesizes = {
+        5: serial.FIVEBITS,
+        6: serial.SIXBITS,
+        7: serial.SEVENBITS,
+        8: serial.EIGHTBITS,
+        }
 
-    _parities = {'NONE': serial.PARITY_NONE,
-                  'EVEN': serial.PARITY_EVEN,
-                  'ODD': serial.PARITY_ODD,
-                  'MARK': serial.PARITY_MARK,
-                  'SPACE': serial.PARITY_SPACE
-                  }
+    _parities = {
+        'NONE': serial.PARITY_NONE,
+        'EVEN': serial.PARITY_EVEN,
+        'ODD': serial.PARITY_ODD,
+        'MARK': serial.PARITY_MARK,
+        'SPACE': serial.PARITY_SPACE
+    }
 
-    _stopbits = {'ONE': serial.STOPBITS_ONE,
-                  'ONE_AND_HALF': serial.STOPBITS_ONE_POINT_FIVE,
-                  'TWO': serial.STOPBITS_TWO
-                  }
+    _stopbits = {
+        'ONE': serial.STOPBITS_ONE,
+        'ONE_AND_HALF': serial.STOPBITS_ONE_POINT_FIVE,
+        'TWO': serial.STOPBITS_TWO
+    }
 
     DEVICE_TIMEBASE_TO_SEC = 1.0
     _newDataTypes = [('port', N.str, 32), ('baud', N.str, 32),]
     EVENT_CLASS_NAMES = ['SerialInputEvent','SerialByteChangeEvent']
     DEVICE_TYPE_ID = DeviceConstants.SERIAL
     DEVICE_TYPE_STRING = "SERIAL"
-    _serial_slots = ['port', 'baud', 'bytesize', 'parity', 'stopbits', '_serial', '_timeout', '_rx_buffer',
-                  '_parser_config', '_parser_state', '_event_count',
-                  '_byte_diff_mode','_custom_parser','_custom_parser_kwargs']
+    _serial_slots = [
+        'port', 'baud', 'bytesize', 'parity', 'stopbits', '_serial',
+        '_timeout', '_rx_buffer', '_parser_config', '_parser_state',
+        '_event_count', '_byte_diff_mode', '_custom_parser',
+        '_custom_parser_kwargs'
+    ]
     __slots__ = [e for e in _serial_slots]
 
     def __init__(self, *args, **kwargs):
@@ -59,7 +66,11 @@ class Serial(Device):
             if pports:
                 self.port = pports[0]
                 if len(pports) > 1:
-                    print2err("Warning: Serial device port configuration set to 'auto'.\nMultiple serial ports found:\n", pports, "\n** Using port ", self.port)
+                    print2err(
+                        "Warning: Serial device port configuration set "
+                        "to 'auto'.\nMultiple serial ports found:\n",
+                        pports, "\n** Using port ", self.port
+                    )
         self.baud = self.getConfiguration().get('baud')
         self.bytesize = self._bytesizes[self.getConfiguration().get('bytesize')]
         self.parity = self._parities[self.getConfiguration().get('parity')]
@@ -110,7 +121,9 @@ class Serial(Device):
                 mod = importlib.import_module(mod_name)
                 self._custom_parser = getattr(mod, func_name)
             except:
-                print2err("ioHub Serial Device Error: could not load custom_parser function: ",custom_parser_func_str)
+                print2err(
+                    "ioHub Serial Device Error: could not load "
+                    "custom_parser function: ", custom_parser_func_str)
                 printExceptionDetailsToStdErr()
 
             if self._custom_parser:
@@ -151,7 +164,7 @@ class Serial(Device):
             available = [port[0] for port in list_ports.comports()]
 
         if len(available) < 1:
-            print2err('Error: unable to find any serial ports on the computer.')
+            print2err("Error: unable to find any serial ports on the computer.")
             return []
         return available
 
@@ -464,12 +477,12 @@ class Serial(Device):
 class Pstbox(Serial):
     """
     Provides convenient access to the PST Serial Response Box.
-
     """
     EVENT_CLASS_NAMES = ['SerialInputEvent', 'PstboxButtonEvent']
     DEVICE_TYPE_ID = DeviceConstants.PSTBOX
     DEVICE_TYPE_STRING = 'PSTBOX'
-    # Only add new attributes for the subclass, the device metaclass pulls them together. 
+    # Only add new attributes for the subclass, the device metaclass
+    # pulls them together.
     _serial_slots = [
         '_nlamps', '_lamp_state',
         '_streaming_state', '_button_query_state', '_state',
@@ -480,10 +493,6 @@ class Pstbox(Serial):
     def __init__(self, *args, **kwargs):
         Serial.__init__(self, *args, **kwargs)
 
-        # Any class instance attribute must be specified in the __slots__ list.
-        # So '_nbuttons' needs to be added to __slots__ for this class.
-        # If uses a class level attribute, when it makes sense, then this does not need to
-        # be in slots.
         self._nbuttons = 5
         # Buttons 0--4, from left to right:
         # [1, 2, 4, 8, 16]
@@ -505,7 +514,7 @@ class Pstbox(Serial):
     def _update_state(self):
         update_lamp_state = True
 
-        # `state` becomes an array of bools.
+        # `state` is an array of bools.
         state = N.r_[
             self._lamp_state, self._button_query_state, update_lamp_state,
             self._streaming_state
@@ -521,20 +530,72 @@ class Pstbox(Serial):
         self._state = state
 
     def getState(self):
+        """
+        Return the current state of the response box.
+
+        Returns
+        -------
+        array
+            An array of 8 boolean values will be returned, corresponding to
+            the following properties:
+            - state of lamp 0 (on/off)
+            - state of lamp 1 (on/off)
+            - state of lamp 2 (on/off)
+            - state of lamp 3 (on/off)
+            - state of lamp 4 (on/off)
+            - button query state (on/off)
+            - update lamp state (yes/no)
+            - streaming state (on/off)
+
+        See Also
+        --------
+        setState
+
+        """
         return self._state
 
     def getLampState(self):
+        """
+        Return the current state of the lamps.
+
+        Returns
+        -------
+        array
+            An array of 5 boolean values will be returned, corresponding to
+            the following properties:
+            - state of lamp 0 (on/off)
+            - state of lamp 1 (on/off)
+            - state of lamp 2 (on/off)
+            - state of lamp 3 (on/off)
+            - state of lamp 4 (on/off)
+
+        See Also
+        --------
+        setLampState
+
+        """
         return self._lamp_state
 
     def setLampState(self, state):
         """
-        Change the state of the lamps (on/off)
+        Change the state of the lamps (on/off).
 
         Parameters
         ----------
         state : array_like
-            The requested lamp states, from left to right. `0` means off,
-            and `1` means on.
+            The requested lamp states, from left to right. `0` or `False`
+            means off, and `1` or `True` means on. This method expects
+            an array of 5 boolean values, each corresponding to the
+            following properties:
+            - state of lamp 0 (on/off)
+            - state of lamp 1 (on/off)
+            - state of lamp 2 (on/off)
+            - state of lamp 3 (on/off)
+            - state of lamp 4 (on/off)
+
+        See Also
+        --------
+        getLampState
 
         """
         if len(state) != self._nlamps:
@@ -547,22 +608,58 @@ class Pstbox(Serial):
         self._update_state()
 
     def getStreamingState(self):
+        """
+        Get the current streaming state.
+
+        Returns
+        -------
+        bool
+            `True` if the box is streaming data, and `False` otherwise.
+
+        See Also
+        --------
+        setStreamingState
+
+        """
         return self._streaming_state
 
     def setStreamingState(self, state):
         """
         Switch on or off streaming mode.
 
+        If streaming mode is disabled, the box will not send anything
+        to the computer.
+
         Parameters
         ----------
         state : bool
             ``True`` will enable streaming, ``False`` will disable it.
+
+        See Also
+        --------
+        getStreamingState
 
         """
         self._streaming_state = bool(state)
         self._update_state()
 
     def getButtonQueryState(self):
+        """
+        Get the current button query state.
+
+        If the box is not querying buttons, no button presses will
+        be reported.
+
+        Returns
+        -------
+        bool
+            `True` if the box is streaming data, and `False` otherwise.
+
+        See Also
+        --------
+        getButtonQueryState
+
+        """
         return self._button_query_state
 
     def setButtonQueryState(self, state):
@@ -573,6 +670,10 @@ class Pstbox(Serial):
         ----------
         state : bool
             ``True`` will enable querying, ``False`` will disable it.
+
+        See Also
+        --------
+        getButtonQueryState
 
         """
         self._button_query_state = bool(state)
@@ -637,10 +738,13 @@ class SerialByteChangeEvent(DeviceEvent):
     def __init__(self, *args, **kwargs):
         DeviceEvent.__init__(self, *args, **kwargs)
 
+
 class PstboxButtonEvent(DeviceEvent):
     # Add new fields for PstboxButtonEvent
     _newDataTypes = [
-        ('port', N.str, 32), # could be needed to identify events from >1 connected button box; if that is ever supported.
+        ('port', N.str, 32),  # could be needed to identify events
+                              # from >1 connected button box; if that is
+                              # ever supported.
         ('button', N.uint8),
         ('button_event', N.str, 7)
     ]

--- a/psychopy/iohub/devices/serial/__init__.py
+++ b/psychopy/iohub/devices/serial/__init__.py
@@ -461,7 +461,7 @@ class Serial(Device):
         Device._close(self)
 
 
-class PSTBox(Serial):
+class PstBox(Serial):
     """
     Provides convenient access to the PST Serial Response Box.
 
@@ -652,25 +652,16 @@ class PstBoxButtonEvent(DeviceEvent):
 
     __slots__ = [e[0] for e in _newDataTypes]
     
-    # As is, this event will not work. This is because new fields have been added
-    # for the event. iohub not only supports streaming of events to psychopy at runtime, but
-    # it also stores events in the 'datastore', which is an hdf5 structured file.
-    # Each event type that has a specific set of fields different from other events must 
-    # have a table created to hold the event types data. Each table as columns that are created from
-    # the event classes datatypes dtype definition string.
-    
-    # Need to first know if this event type really should have  / needs the prev_byte and current_byte
-    # fields created in the SerialByteChangeEvent. If it does, then
-    # extending SerialByteChangeEvent as is done now makes sense . 
-    # If it does not need these fields, then it would be better
-    # to extend the base DeviceEvent class. 
+    # This should now work assuming prev_byte and current_byte fields are
+    # really wanted for this event type.
     
     # Regardless, the following changes need to be added to this file, 
     EVENT_TYPE_ID = EventConstants.PSTBOX_BUTTON
     EVENT_TYPE_STRING = 'PSTBOX_BUTTON'
     IOHUB_DATA_TABLE = EVENT_TYPE_STRING    
     
-    # TODO: and an update to constants.py and maybe datastore.__init__.py will be needed
+    # DONE: Update constants.py and iohub.datastore.__init__.py to add PSTBOX_BUTTON and event type
+    # table creation
 
     # Specify Event constants associated with the event class, 
     # and the key to the hdf5 table these events should be stored in.

--- a/psychopy/iohub/devices/serial/default_pstbox.yaml
+++ b/psychopy/iohub/devices/serial/default_pstbox.yaml
@@ -1,0 +1,138 @@
+# This file includes all valid mcu.iosync.ioSync Device
+# settings that can be specified in an iohub_config.yaml
+# or in a Python dictionary form and passed to the quickStartHubServer
+# method. Any device parameters not specified when the device class is
+# created by the ioHub Process will be assigned the default value
+# indicated here.
+#
+serial.PSTBox:
+    
+    # name: The unique name to assign to the device instance created.
+    #   The device is accessed from within the PsychoPy script 
+    #   using the name's value; therefore it must be a valid Python
+    #   variable name as well.
+    #
+    name: pstbox
+
+    # monitor_event_types: Specify which of the device's supported event
+    #   types you would like the ioHub to monitor for.
+    #
+    monitor_event_types: [SerialInputEvent, SerialByteChangeEvent]
+    # serial_port: On Windows, serial ports will be in the form
+    #    'COMx', where x is the serial port number, usually ranging between 1 
+    #    and 32. For example, COM6 would indicate that serial port 6 should be
+    #    used.
+    #    For Linux and OS X, serial ports are usually specified as ... TBC
+    #    To autodetect an ioSync, set to 'auto'.
+    port: auto
+
+    baud: 19200
+
+    bytesize: 8
+
+    parity: NONE
+
+    stopbits: ONE
+
+    event_parser:
+        fixed_length: 255
+        prefix:
+        delimiter:
+        byte_diff: True
+
+    # device_timer: Devices that require polling to read any new native events
+    #   that have become available must specifiy a device_timer property, with an
+    #   interval sub property that specifies how frequently the device would be polled
+    #   by the ioHub Server. The time is specified in sec.msec format and is a 'requested'
+    #   polling interval. The actual polling interval will vary from this somewhat, the 
+    #   magnitude of which depends on the computer hardware and OS being used and the
+    #   number of other polled devices being monitored. The 'configdence_interval'
+    #   attribute of events that have a parent device that is polled often can be used to
+    #   determine the actual polling rate being achieved by the ioHub Process.
+    device_timer:
+        interval: 0.0005
+
+    # enable: Specifies if the device should be enabled by ioHub and monitored
+    #   for events.
+    #   True = Enable the device on the ioHub Server Process
+    #   False = Disable the device on the ioHub Server Process. No events for
+    #   this device will be reported by the ioHub Server.
+    #    
+    enable: True
+
+    # save_events: *If* the ioHubDataStore is enabled for the experiment, then
+    #   indicate if events for this device should be saved to the
+    #   data_collection/keyboard event group in the hdf5 event file.
+    #   True = Save events for this device to the ioDataStore.
+    #   False = Do not save events for this device in the ioDataStore.
+    #    
+    save_events: True
+
+    # stream_events: Indicate if events from this device should be made available
+    #   during experiment runtime to the PsychoPy Process.
+    #   True = Send events for this device to  the PsychoPy Process in real-time.
+    #   False = Do *not* send events for this device to the PsychoPy Process in real-time.
+    #    
+    stream_events: True
+
+    # auto_report_events: Indicate if events from this device should start being
+    #   processed by the ioHub as soon as the device is loaded at the start of an experiment,
+    #   or if events should only start to be monitored on the device when a call to the
+    #   device's enableEventReporting method is made with a parameter value of True.
+    #   True = Automatically start reporting events for this device when the experiment starts.
+    #   False = Do not start reporting events for this device until enableEventReporting(True)
+    #   is set for the device during experiment runtime.
+    #
+    auto_report_events: False
+
+    # event_buffer_length: Specify the maximum number of events (for each
+    #   event type the device produces) that can be stored by the ioHub Server
+    #   before each new event results in the oldest event of the same type being
+    #   discarded from the ioHub device event buffer.
+    #
+    event_buffer_length: 1024
+
+    # The MCU device manufacturer's name.
+    # N/A
+    #
+    manufacturer_name: Psychology Software Tools
+
+    # model_name: The serial port card model name.
+    #   Currently, this field is not used.
+    #
+    model_name: Serial Response Box
+
+    # The serial number for the specific isnstance of device used
+    #   can be specified here. It is not used by the ioHub, so is FYI only.
+    #
+    serial_number: SRB200-07830
+
+    # manufacture_date: The date of manufactiurer of the device 
+    # can be specified here. It is not used by the ioHub,
+    # so is FYI only.
+    #   
+    manufacture_date: DD-MM-YYYY
+
+    # The device's hardware version can be specified here.
+    #   It is not used by the ioHub, so is FYI only.
+    #
+    hardware_version: N/A
+    
+    # If the device has firmware, its revision number
+    #   can be indicated here. It is not used by the ioHub, so is FYI only.
+    #
+    firmware_version: N/A
+
+    # The device model number can be specified here.
+    #   It is not used by the ioHub, so is FYI only.
+    #
+    model_number: 200A
+    
+    # The device driver and / or SDK software version number.
+    #   This field is not used by ioHub, so is FYI only. 
+    software_version: N/A
+
+    # The device number to assign to the Analog Input device. 
+    #   device_number is not used by this device type.
+    #
+    device_number: 0

--- a/psychopy/iohub/devices/serial/default_pstbox.yaml
+++ b/psychopy/iohub/devices/serial/default_pstbox.yaml
@@ -5,7 +5,7 @@
 # created by the ioHub Process will be assigned the default value
 # indicated here.
 #
-serial.PstBox:
+serial.Pstbox:
     
     # name: The unique name to assign to the device instance created.
     #   The device is accessed from within the PsychoPy script 
@@ -17,7 +17,7 @@ serial.PstBox:
     # monitor_event_types: Specify which of the device's supported event
     #   types you would like the ioHub to monitor for.
     #
-    monitor_event_types: [SerialInputEvent, PstBoxButtonEvent]
+    monitor_event_types: [SerialInputEvent, PstboxButtonEvent]
     # serial_port: On Windows, serial ports will be in the form
     #    'COMx', where x is the serial port number, usually ranging between 1 
     #    and 32. For example, COM6 would indicate that serial port 6 should be

--- a/psychopy/iohub/devices/serial/default_pstbox.yaml
+++ b/psychopy/iohub/devices/serial/default_pstbox.yaml
@@ -5,7 +5,7 @@
 # created by the ioHub Process will be assigned the default value
 # indicated here.
 #
-serial.PSTBox:
+serial.PstBox:
     
     # name: The unique name to assign to the device instance created.
     #   The device is accessed from within the PsychoPy script 
@@ -17,7 +17,7 @@ serial.PSTBox:
     # monitor_event_types: Specify which of the device's supported event
     #   types you would like the ioHub to monitor for.
     #
-    monitor_event_types: [SerialInputEvent, SerialByteChangeEvent]
+    monitor_event_types: [SerialInputEvent, PstBoxButtonEvent]
     # serial_port: On Windows, serial ports will be in the form
     #    'COMx', where x is the serial port number, usually ranging between 1 
     #    and 32. For example, COM6 would indicate that serial port 6 should be

--- a/psychopy/iohub/devices/serial/supported_config_settings.yaml
+++ b/psychopy/iohub/devices/serial/supported_config_settings.yaml
@@ -1,4 +1,4 @@
-mcu.iosync.MCU:
+serial.Serial:
     enable: IOHUB_BOOL
     name:
         IOHUB_STRING:
@@ -101,6 +101,113 @@ mcu.iosync.MCU:
             min_length: 1
             max_length: 8
     firmware_version: 
+        IOHUB_STRING:
+            min_length: 1
+            max_length: 8
+
+serial.PSTBox:
+    enable: IOHUB_BOOL
+    name:
+        IOHUB_STRING:
+            min_length: 1
+            max_length: 32
+            first_char_alpha: True
+    port:
+        IOHUB_STRING:
+            min_length: 1
+            max_length: 32
+    baud:
+        IOHUB_INT:
+            min: 1
+            max: 1000000
+    bytesize:
+        IOHUB_INT:
+            min: 5
+            max: 8
+
+    parity:
+        IOHUB_LIST:
+            valid_values: [NONE, EVEN, ODD, MARK, SPACE]
+            min_length: 1
+            max_length: 1
+
+    stopbits:
+        IOHUB_LIST:
+            valid_values: [ONE, ONE_AND_HALF, TWO]
+            min_length: 1
+            max_length: 1
+
+    event_parser:
+        fixed_length:
+            IOHUB_INT:
+                min: 0
+                max: 256
+        prefix:
+            IOHUB_STRING:
+                min_length: 0
+                max_length: 32
+                first_char_alpha: False
+        delimiter:
+            IOHUB_STRING:
+                min_length: 0
+                max_length: 32
+                first_char_alpha: False
+        byte_diff: IOHUB_BOOL
+        parser_function:
+            IOHUB_STRING:
+                min_length: 0
+                max_length: 64
+                first_char_alpha: True
+        parser_kwargs:
+            IOHUB_LIST:
+                valid_values:
+                min_length: 0
+                max_length: 1024
+
+    device_timer:
+        interval:
+            IOHUB_FLOAT:
+                min: 0.0001
+                max: 0.500
+    save_events: IOHUB_BOOL
+    stream_events: IOHUB_BOOL
+    auto_report_events: False
+    monitor_event_types:
+        IOHUB_LIST:
+            valid_values: [SerialInputEvent, SerialByteChangeEvent]
+            min_length: 0
+            max_length: 2
+    event_buffer_length:
+        IOHUB_INT:
+            min: 1
+            max: 2048
+    device_number: 0
+    model_name:
+        IOHUB_STRING:
+            min_length: 0
+            max_length: 32
+    manufacturer_name:
+        IOHUB_STRING:
+            min_length: 0
+            max_length: 32
+    serial_number:
+        IOHUB_STRING:
+            min_length: 1
+            max_length: 32
+    model_number:
+        IOHUB_STRING:
+            min_length: 1
+            max_length: 16
+    manufacture_date: IOHUB_DATE
+    software_version:
+        IOHUB_STRING:
+            min_length: 1
+            max_length: 8
+    hardware_version:
+        IOHUB_STRING:
+            min_length: 1
+            max_length: 8
+    firmware_version:
         IOHUB_STRING:
             min_length: 1
             max_length: 8

--- a/psychopy/iohub/devices/serial/supported_config_settings.yaml
+++ b/psychopy/iohub/devices/serial/supported_config_settings.yaml
@@ -105,7 +105,7 @@ serial.Serial:
             min_length: 1
             max_length: 8
 
-serial.PSTBox:
+serial.PstBox:
     enable: IOHUB_BOOL
     name:
         IOHUB_STRING:
@@ -174,7 +174,7 @@ serial.PSTBox:
     auto_report_events: False
     monitor_event_types:
         IOHUB_LIST:
-            valid_values: [SerialInputEvent, SerialByteChangeEvent]
+            valid_values: [SerialInputEvent, PstBoxButtonEvent]
             min_length: 0
             max_length: 2
     event_buffer_length:

--- a/psychopy/iohub/devices/serial/supported_config_settings.yaml
+++ b/psychopy/iohub/devices/serial/supported_config_settings.yaml
@@ -67,7 +67,7 @@ serial.Serial:
     auto_report_events: False    
     monitor_event_types:
         IOHUB_LIST:
-            valid_values: [SerialInputEvent, SerialByteChangeEvent]
+            valid_values: [SerialInputEvent, SerialByteChangeEvent, PstboxButtonEvent]
             min_length: 0
             max_length: 2
     event_buffer_length:
@@ -105,7 +105,7 @@ serial.Serial:
             min_length: 1
             max_length: 8
 
-serial.PstBox:
+serial.Pstbox:
     enable: IOHUB_BOOL
     name:
         IOHUB_STRING:
@@ -174,7 +174,7 @@ serial.PstBox:
     auto_report_events: False
     monitor_event_types:
         IOHUB_LIST:
-            valid_values: [SerialInputEvent, PstBoxButtonEvent]
+            valid_values: [SerialInputEvent, PstboxButtonEvent]
             min_length: 0
             max_length: 2
     event_buffer_length:

--- a/psychopy/iohub/devices/serial/supported_config_settings_pstbox.yaml
+++ b/psychopy/iohub/devices/serial/supported_config_settings_pstbox.yaml
@@ -1,10 +1,10 @@
-serial.Serial:
+serial.Pstbox:
     enable: IOHUB_BOOL
     name:
         IOHUB_STRING:
             min_length: 1
             max_length: 32
-            first_char_alpha: True    
+            first_char_alpha: True
     port:
         IOHUB_STRING:
             min_length: 1
@@ -60,20 +60,20 @@ serial.Serial:
     device_timer:
         interval:
             IOHUB_FLOAT:
-                min: 0.001
+                min: 0.0001
                 max: 0.500
     save_events: IOHUB_BOOL
     stream_events: IOHUB_BOOL
-    auto_report_events: False    
+    auto_report_events: False
     monitor_event_types:
         IOHUB_LIST:
-            valid_values: [SerialInputEvent, SerialByteChangeEvent]
+            valid_values: [SerialInputEvent, PstboxButtonEvent]
             min_length: 0
             max_length: 2
     event_buffer_length:
         IOHUB_INT:
             min: 1
-            max: 2048    
+            max: 2048
     device_number: 0
     model_name:
         IOHUB_STRING:
@@ -95,12 +95,12 @@ serial.Serial:
     software_version:
         IOHUB_STRING:
             min_length: 1
-            max_length: 8    
-    hardware_version: 
+            max_length: 8
+    hardware_version:
         IOHUB_STRING:
             min_length: 1
             max_length: 8
-    firmware_version: 
+    firmware_version:
         IOHUB_STRING:
             min_length: 1
             max_length: 8


### PR DESCRIPTION
This adds support for the PST Serial Response Box.

Data streaming and button querying can be turned on/off via ``setStreamingState`` and ``setButtonQueryState``, respectively. Also, the lamps can be controlled using ``setLampState``. Equivalent ``get*`` methods exist too, of course.

Right now, support is limited to the five buttons and lamps of the standard box. Support for the microphone and refresh detector could easily be added.