### PR TITLE
RF/ENH: Update to use ioHub's serial.Pstbox

### DIFF
--- a/psychopy/demos/coder/iohub/serial/pstbox.py
+++ b/psychopy/demos/coder/iohub/serial/pstbox.py
@@ -1,8 +1,10 @@
 from __future__ import print_function
+
 import time
 import numpy as np
 from psychopy import core, visual
 from psychopy.iohub import launchHubServer
+from psychopy.iohub.devices import Computer
 
 #####################################################################
 
@@ -18,28 +20,21 @@ BAUDRATE = 19200
 psychopy_mon_name = 'Monitor_01'
 exp_code = 'pstbox'
 sess_code = 'S_{0}'.format(long(time.mktime(time.localtime())))
-iohubkwargs = {'psychopy_monitor_name': psychopy_mon_name,
-               'experiment_code': exp_code,
-               'session_code': sess_code,
-               'serial.Serial': dict(name='serial', port=SERIAL_PORT, baud=BAUDRATE,
-                                     event_parser=dict(byte_diff=True))}
+iohubkwargs = {
+    'psychopy_monitor_name': psychopy_mon_name,
+    'experiment_code': exp_code,
+    'session_code': sess_code,
+    'serial.Pstbox': dict(name='pstbox', port=SERIAL_PORT, baud=BAUDRATE)
+}
 
-# start the iohub server and set up display and PST box devices
+# Start the iohub server and set up devices.
 io = launchHubServer(**iohubkwargs)
+computer = Computer
 display = io.devices.display
-pstbox = io.devices.serial
+pstbox = io.devices.pstbox
 
-# Prepare the PST box.
-#
-# Bit 7 = 128 -> Enable/Disable streaming.
-# Bit 6 =  64 -> Lower bits control lamp state.
-# Bit 5 =  32 -> Enable/Disable button queries.
-# Bit 0-4 = 1-16 -> Enable/Disable Lamp 0-4.
-#
-# Source: https://psychtoolbox-3.googlecode.com/svn/beta/Psychtoolbox/PsychHardware/CMUBox.m
-print('Switching response box to streaming mode and switching on lamp #3...')
-pstbox.write(chr(np.uint8(128+32+64+4)))
-core.wait(0.25)
+print('Switching on lamp #3...')
+pstbox.setLampState([0, 0, 1, 0, 0])
 print('...done.')
 
 # Start collecting data from the PST box in the background.
@@ -58,11 +53,15 @@ win = visual.Window(display.getPixelResolution(),
 #
 
 # Instruction text.
-instruction = visual.TextStim(win, text='Push a button as soon as the colored figure appears.\n\nPush any button to start.')
+instruction = visual.TextStim(
+    win,
+    text='Push a button as soon as the colored figure appears.\n\n'
+         'Push any button to start.')
 
 # Fixation spot.
 fixSpot = visual.PatchStim(win, tex='none', mask='gauss',
-                           pos=(0, 0), size=(30, 30), color='black', autoLog=False)
+                           pos=(0, 0), size=(30, 30), color='black',
+                           autoLog=False)
 
 # Visual stimulus.
 grating = visual.PatchStim(win, pos=(0, 0),
@@ -80,7 +79,7 @@ grating = visual.PatchStim(win, pos=(0, 0),
 # Display instruction.
 instruction.draw()
 win.flip()
-io.clearEvents('serial')
+pstbox.clearEvents()
 # Check if we collected any button events.
 # If we did, use the first one to determine response time.
 while not pstbox.getEvents():
@@ -90,44 +89,56 @@ win.flip()
 
 nreps = 10
 RT = np.array([])
-core.wait(2)
+button = np.array([])
+io.wait(2)
 
 for i in range(nreps):
     print('Trial #', i)
+
+    # Raise process prioritoes.
+    computer.setPriority('high')
+    io.setPriority('high')
 
     # Draw the fixation.
     fixSpot.draw()
     win.flip()
 
-    # Clear the PST box event buffers immediately after the fixation is displayed.
-    io.clearEvents('serial')
+    # Clear the PST box event buffers immediately after the
+    # fixation is displayed.
+    pstbox.clearEvents()
 
     # Wait a variable time until the stimulus is being presented.
-    core.wait(1+np.random.rand())
+    io.wait(1+np.random.rand())
 
     # Draw the stimulus.
     grating.draw()
     t0 = win.flip()
-    core.wait(0.5)
+    io.wait(0.5)
 
     # Clear the screen and wait a little while for possible late responses.
     win.flip()
-    core.wait(0.25)
+    io.wait(0.25)
+
+    # Lower process priorities.
+    computer.setPriority('normal')
+    io.setPriority('normal')
 
     # Check if we collected any button events.
     # If we did, use the first one to determine response time.
     pstevents = pstbox.getEvents()
     if pstevents:
         RT = np.append(RT, pstevents[0].time - t0)
-        print('RT:', RT[-1])
+        button = np.append(button, pstevents[0].button)
+        print('RT: %f, Button: %d' % (RT[-1], button[-1]))
     else:
         RT = np.append(RT, np.nan)
+        button = np.append(button, np.nan)
         print('No response.')
 
     print('---')
 
     # ITI
-    core.wait(2)
+    io.wait(2)
 
 #####################################################################
 
@@ -135,8 +146,8 @@ for i in range(nreps):
 # All data collected; print some results.
 #
 
-print('Collected', np.count_nonzero(~np.isnan(RT)), 'responses.')
-print('Mean RT:', np.nanmean(RT), 's')
+print('Collected %d responses.' % np.count_nonzero(~np.isnan(RT)))
+print('Mean RT: %f s' % np.nanmean(RT))
 print('---')
 
 #####################################################################
@@ -147,7 +158,7 @@ print('---')
 
 # Stop recording events from the PST box and switch off all lamps.
 pstbox.enableEventReporting(False)
-pstbox.write(chr(np.uint8(64)))
+pstbox.setLampState([0, 0, 0, 0, 0])
 
 # Close the window and quit the program.
 io.quit()


### PR DESCRIPTION
This updates the demo to use ioHub's new serial.Pstbox device instead of the previous generic serial.Serial interface. It demonstrates how to acquire response times for button presses and how to operate the lamps.