### PR TITLE
Cleanups & Auto-Report PST Events by Default

### DIFF
--- a/psychopy/demos/coder/iohub/serial/pstbox.py
+++ b/psychopy/demos/coder/iohub/serial/pstbox.py
@@ -16,7 +16,7 @@ from psychopy.iohub.devices import Computer
 SERIAL_PORT = 'COM5'
 BAUDRATE = 19200
 
-# configure iohub
+# ioHub configuration.
 psychopy_mon_name = 'Monitor_01'
 exp_code = 'pstbox'
 sess_code = 'S_{0}'.format(long(time.mktime(time.localtime())))
@@ -37,14 +37,12 @@ print('Switching on lamp #3...')
 pstbox.setLampState([0, 0, 1, 0, 0])
 print('...done.')
 
-# Start collecting data from the PST box in the background.
-pstbox.enableEventReporting(True)
-
 # Create a window.
-win = visual.Window(display.getPixelResolution(),
-                    units='pix',
-                    fullscr=True, allowGUI=False,
-                    screen=0)
+win = visual.Window(
+    display.getPixelResolution(),
+    units='pix', fullscr=True, allowGUI=False,
+    screen=0
+)
 
 #####################################################################
 
@@ -56,19 +54,24 @@ win = visual.Window(display.getPixelResolution(),
 instruction = visual.TextStim(
     win,
     text='Push a button as soon as the colored figure appears.\n\n'
-         'Push any button to start.')
+         'Push any button to start.'
+)
 
 # Fixation spot.
-fixSpot = visual.PatchStim(win, tex='none', mask='gauss',
-                           pos=(0, 0), size=(30, 30), color='black',
-                           autoLog=False)
+fixSpot = visual.PatchStim(
+    win, tex='none', mask='gauss',
+    pos=(0, 0), size=(30, 30), color='black',
+    autoLog=False
+)
 
 # Visual stimulus.
-grating = visual.PatchStim(win, pos=(0, 0),
-                           tex='sin', mask='gauss',
-                           color=[1.0, 0.5, -1.0],
-                           size=(300.0, 300.0), sf=(0.01, 0.0),
-                           autoLog=False)
+grating = visual.PatchStim(
+    win, pos=(0, 0),
+    tex='sin', mask='gauss',
+    color=[1.0, 0.5, -1.0],
+    size=(300.0, 300.0), sf=(0.01, 0.0),
+    autoLog=False
+)
 
 #####################################################################
 
@@ -76,19 +79,20 @@ grating = visual.PatchStim(win, pos=(0, 0),
 # Start the experiment.
 #
 
-# Display instruction.
 pstbox.clearEvents()
-ctime = core.getTime()
-# Check if we collected any button events.
-# If we did, use the first one to determine response time.
+start_time = computer.getTime()
+
+# Display instruction and check if we collected any button events.
+# If there is no button press within a 30 s period, quit.
+instruction.draw()
+win.flip()
 while not pstbox.getEvents():
-     instruction.draw()
-     win.flip()
-     if core.getTime()-ctime > 30.0:
-        print("Timeout waiting for button event. Exiting...")
+    if core.getTime() - start_time > 30:
+        print('Timeout waiting for button event. Exiting...')
         io.quit()
         core.quit()
 
+# Clear the screen.
 win.flip()
 
 nreps = 10
@@ -99,7 +103,7 @@ io.wait(2)
 for i in range(nreps):
     print('Trial #', i)
 
-    # Raise process prioritoes.
+    # Raise process priorities.
     computer.setPriority('high')
     io.setPriority('high')
 
@@ -112,9 +116,9 @@ for i in range(nreps):
     pstbox.clearEvents()
 
     # Wait a variable time until the stimulus is being presented.
-    io.wait(1+np.random.rand())
+    io.wait(1 + np.random.rand())
 
-    # Draw the stimulus.
+    # Draw the stimulus and have it displayed for approx. 0.5 s.
     grating.draw()
     t0 = win.flip()
     io.wait(0.5)
@@ -160,8 +164,7 @@ print('---')
 # Shut down.
 #
 
-# Stop recording events from the PST box and switch off all lamps.
-pstbox.enableEventReporting(False)
+# Switch off all lamps.
 pstbox.setLampState([0, 0, 0, 0, 0])
 
 # Close the window and quit the program.

--- a/psychopy/iohub/devices/serial/default_pstbox.yaml
+++ b/psychopy/iohub/devices/serial/default_pstbox.yaml
@@ -83,7 +83,7 @@ serial.Pstbox:
     #   False = Do not start reporting events for this device until enableEventReporting(True)
     #   is set for the device during experiment runtime.
     #
-    auto_report_events: False
+    auto_report_events: True
 
     # event_buffer_length: Specify the maximum number of events (for each
     #   event type the device produces) that can be stored by the ioHub Server

--- a/psychopy/iohub/devices/serial/supported_config_settings.yaml
+++ b/psychopy/iohub/devices/serial/supported_config_settings.yaml
@@ -64,7 +64,7 @@ serial.Serial:
                 max: 0.500
     save_events: IOHUB_BOOL
     stream_events: IOHUB_BOOL
-    auto_report_events: False    
+    auto_report_events: IOHUB_BOOL
     monitor_event_types:
         IOHUB_LIST:
             valid_values: [SerialInputEvent, SerialByteChangeEvent]

--- a/psychopy/iohub/devices/serial/supported_config_settings_pstbox.yaml
+++ b/psychopy/iohub/devices/serial/supported_config_settings_pstbox.yaml
@@ -64,7 +64,7 @@ serial.Pstbox:
                 max: 0.500
     save_events: IOHUB_BOOL
     stream_events: IOHUB_BOOL
-    auto_report_events: False
+    auto_report_events: IOHUB_BOOL
     monitor_event_types:
         IOHUB_LIST:
             valid_values: [PstboxButtonEvent,]


### PR DESCRIPTION
These changes are mostly cosmetic, except for the following:

* Both the ``serial.Serial`` and ``serial.Pstbox`` devices' ``supported_config_settings*.yaml`` files now have ``auto_report_events`` set to ``IOHUB_BOOL`` (was ``False`` before), allowing us to either enable or disable event reporting on device creation time via a setting in ``default_config_settings*.yaml``
* .The ``Pstbox`` device is now reporting events by default, i.e. the user does not have to manually invoke ``enableEventReporting(True)`` anymore. This is easily justified in that the only purpose of the ``Pstbox`` is to collect responses, which are very few in number, hence even constant event processing will cause close to none additional load.